### PR TITLE
Experience page with click inside for details

### DIFF
--- a/lib/Forum/Forum.dart
+++ b/lib/Forum/Forum.dart
@@ -1,8 +1,38 @@
 import 'package:flutter/material.dart';
+import 'package:travel_app/Forum/forum_grids.dart';
 
-class Forum extends StatelessWidget {
+class Forum extends StatefulWidget 
+{
+  const Forum({super.key});
   @override
-  Widget build(BuildContext context) {
-    return SizedBox();
+  State<Forum> createState() => _ForumState();
+}
+
+class _ForumState extends State<Forum>
+{
+  @override
+  Widget build(BuildContext context)
+  {
+    return SafeArea(
+      child: ListView(
+        children: [
+          Padding(
+            padding: EdgeInsets.symmetric(vertical: 10, horizontal: 10),
+            child: Row(
+              children: [
+                Text(
+                  'Experiences',
+                  style: TextStyle(
+                    fontWeight: FontWeight.w600,
+                    fontSize: 20
+                  ),
+                ),
+              ],
+            ),
+          ),
+          ExperienceGrids()
+        ],
+      ),
+    );
   }
 }

--- a/lib/Forum/forum_grids.dart
+++ b/lib/Forum/forum_grids.dart
@@ -3,7 +3,7 @@ import 'package:travel_app/Forum/post_detail.dart';
 import 'package:travel_app/Models/post.dart';
 import 'package:flutter_staggered_grid_view/flutter_staggered_grid_view.dart';
 
-class ExperienceGrids extends StatefulWidget
+class ExperienceGrids extends StatefulWidget 
 {
   const ExperienceGrids({super.key});
 
@@ -11,15 +11,13 @@ class ExperienceGrids extends StatefulWidget
   State<ExperienceGrids> createState() => _ExperienceGridsState();
 }
 
-class _ExperienceGridsState extends State<ExperienceGrids>
+class _ExperienceGridsState extends State<ExperienceGrids> 
 {
   List<Post> posts = [];
 
   @override
-  void initState()
-  {
+  void initState() {
     super.initState();
-    
     posts = Post.getAllPosts();
   }
 
@@ -32,154 +30,178 @@ class _ExperienceGridsState extends State<ExperienceGrids>
 
   void getInPost(BuildContext context, int index) 
   {
-    Navigator.of(
-      context
-    ).push(MaterialPageRoute(builder: (ctx) => PostDetail(
-      post: posts[index], 
-      onToggleLike: () {
-        _toggleLike(index);
-      }
-    )));
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder:
+          (ctx) => PostDetail(
+            post: posts[index],
+            onToggleLike: () {
+              _toggleLike(index);
+            },
+          ),
+      ),
+    );
   }
 
   @override
-  Widget build(BuildContext context)
+  Widget build(BuildContext context) 
   {
-    return SafeArea(
-      child: Padding(
-        padding: const EdgeInsets.all(10.0),
-        child: GridView.custom(
-          shrinkWrap: true,
-          physics: NeverScrollableScrollPhysics(),
+    return Padding(
+      padding: const EdgeInsets.all(10.0),
+      child: MasonryGridView.count(
+        shrinkWrap: true, 
+        physics: const NeverScrollableScrollPhysics(), 
+        crossAxisCount: 2, 
+        mainAxisSpacing: 10.0, 
+        crossAxisSpacing: 10.0, 
+        itemCount: posts.length, 
+        itemBuilder: (BuildContext context, int index) {
+          final Post data = posts[index];
+          final int? postId = data.id;
+          String imageUrl = '';
 
-          gridDelegate: SliverWovenGridDelegate.count(
-            pattern: const [
-              WovenGridTile(1.1),
-              WovenGridTile(
-                5/7,
-                crossAxisRatio: 0.9,
-                alignment: AlignmentDirectional.topEnd
-              ),
-            ], 
-            crossAxisCount: 2,
-            mainAxisSpacing: 2.0,
-            crossAxisSpacing: 2.0
-          ),
-          childrenDelegate: SliverChildBuilderDelegate(
-            (BuildContext context, int index)
+          if (data.images.isNotEmpty) 
+          {
+            imageUrl = data.images[0];
+          }
+
+          double aspectRatio = 1.0;
+          if (postId != null) 
+          {
+            if (postId % 5 == 0) 
             {
-              final Post data = posts[index];
-              return GestureDetector(
-                onTap: () {getInPost(context, index);},
-                child: Container(
-                  decoration: BoxDecoration(
-                    borderRadius: BorderRadius.circular(5),
-                    image: DecorationImage(
-                      image: AssetImage(data.images[0]),
-                      fit: BoxFit.cover
-                    )
-                  ),
-                  child: Column(
-                    children: [
-                      Align(
-                        alignment: Alignment.topLeft,
-                        child: Padding(
-                          padding: const EdgeInsets.all(5.0),
-                          child: Row(
+              aspectRatio = 0.5; // Wider and shorter (2:1 ratio)
+            } 
+            else if (postId % 5 == 1 || postId % 5 == 3) 
+            {
+              aspectRatio = 0.8; // Slightly taller than square (4:5 ratio)
+            } else 
+            {
+              aspectRatio = 1.2; // Taller than square (5:4 ratio)
+            }
+          }
+
+          return GestureDetector(
+            onTap: () {
+              getInPost(context, index);
+            },
+            child: ClipRRect(
+              borderRadius: BorderRadius.circular(12),
+              child: AspectRatio(
+                aspectRatio: aspectRatio,
+                child: Stack(
+                  children: [
+                    Image.asset(
+                      imageUrl,
+                      fit: BoxFit.cover,
+                      width: double.infinity,
+                      height: double.infinity,
+                    ),
+                    Positioned(
+                      top: 8,
+                      left: 8,
+                      right: 8,
+                      child: Row(
+                        children: [
+                          Stack(
                             children: [
-                              Stack(
-                                children: [
-                                  Positioned(
-                                    top: 1.0,
-                                    left: 1.0,
-                                    child: Icon(
-                                      Icons.location_pin,
-                                      size: 21,
-                                      color: Colors.black.withOpacity(0.6), // Darker color for outline
-                                    ),
-                                  ),
-                                  Icon(
-                                    Icons.location_pin,
-                                    size: 20,
-                                    color: Colors.white,
+                              Positioned(
+                                top: 1.0,
+                                left: 1.0,
+                                child: Icon(
+                                  Icons.location_pin,
+                                  size: 21,
+                                  color: Colors.black.withOpacity(0.6),
                                 ),
-                                ],
                               ),
-                              
-                              SizedBox(width: 5),
-                              Text(
-                                data.location,
-                                style: TextStyle(
-                                  color: Colors.white,
-                                  fontSize: 16,
-                                  shadows: [
-                                  Shadow(
-                                    offset: Offset(1.0, 1.0),
-                                    blurRadius: 3.0,
-                                    color: Colors.black.withOpacity(0.6),
-                                  ),
-                                  Shadow(
-                                    offset: Offset(-1.0, -1.0),
-                                    blurRadius: 3.0,
-                                    color: Colors.black.withOpacity(0.6),
-                                  ),
-                                ],
-                                ),
-                              )
+                              const Icon(
+                                Icons.location_pin,
+                                size: 20,
+                                color: Colors.white,
+                              ),
                             ],
                           ),
-                        ),
-                      ),
-                      Spacer(),
-                      Padding(
-                        padding: const EdgeInsets.all(10.0),
-                        child: Row(
-                          children: [
-                            GestureDetector(
-                              onTap: () => _toggleLike(index),
-                              child: Icon(
-                                Icons.favorite,
-                                size: 20,
-                                color: data.isLike ? Colors.red : Colors.white,
-                              ),
-                            ),
-                            Spacer(),
-                            Text(
-                              data.views,
+                          const SizedBox(width: 5),
+                          Flexible(
+                            child: Text(
+                              data.location,
                               style: TextStyle(
-                                color: Colors.white,
+                                color:Colors.white,
                                 fontSize: 16,
                                 shadows: [
                                   Shadow(
-                                    offset: Offset(1.0, 1.0),
+                                    offset: const Offset(1.0, 1.0),
                                     blurRadius: 3.0,
                                     color: Colors.black.withOpacity(0.6),
                                   ),
                                   Shadow(
-                                    offset: Offset(-1.0, -1.0),
+                                    offset: const Offset(-1.0, -1.0),
                                     blurRadius: 3.0,
                                     color: Colors.black.withOpacity(0.6),
                                   ),
-                                ]
+                                ],
+                              ),
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                    Positioned(
+                      bottom: 10,
+                      left: 10,
+                      right: 10,
+                      child: Row(
+                        children: [
+                          InkWell(
+                            onTap:
+                                () => _toggleLike(index),
+                            borderRadius: BorderRadius.circular(20),
+                            child: Padding(
+                              padding: const EdgeInsets.all(4.0),
+                              child: Icon(
+                                Icons.favorite,
+                                size: 20,
+                                color:
+                                    data.isLike? Colors.red: Colors.white,
                               ),
                             ),
-                            SizedBox(width: 5.0),
-                            Icon(
-                              Icons.remove_red_eye_outlined,
-                              size: 20,
-                              color: Colors.white,
+                          ),
+                          const Spacer(),
+                          Text(
+                            data.views,
+                            style: TextStyle(
+                              color:Colors.white,
+                              fontSize: 16,
+                              shadows: [
+                                Shadow(
+                                  offset: const Offset(1.0, 1.0),
+                                  blurRadius: 3.0,
+                                  color: Colors.black.withOpacity(0.6,),
+                                ),
+                                Shadow(
+                                  offset: const Offset(-1.0, -1.0),
+                                  blurRadius: 3.0,
+                                  color: Colors.black.withOpacity(0.6),
+                                ),
+                              ],
                             ),
-                          ],
-                        ),
-                      )
-                    ],
-                  )
-                )
-              );
-            },
-            childCount: posts.length,
-          )
-        ),
+                          ),
+                          const SizedBox(width: 5.0),
+                          const Icon(
+                            Icons.remove_red_eye_outlined,
+                            size: 20,
+                            color: Colors.white
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          );
+        },
       ),
     );
   }

--- a/lib/Forum/forum_grids.dart
+++ b/lib/Forum/forum_grids.dart
@@ -1,0 +1,186 @@
+import 'package:flutter/material.dart';
+import 'package:travel_app/Forum/post_detail.dart';
+import 'package:travel_app/Models/post.dart';
+import 'package:flutter_staggered_grid_view/flutter_staggered_grid_view.dart';
+
+class ExperienceGrids extends StatefulWidget
+{
+  const ExperienceGrids({super.key});
+
+  @override
+  State<ExperienceGrids> createState() => _ExperienceGridsState();
+}
+
+class _ExperienceGridsState extends State<ExperienceGrids>
+{
+  List<Post> posts = [];
+
+  @override
+  void initState()
+  {
+    super.initState();
+    
+    posts = Post.getAllPosts();
+  }
+
+  void _toggleLike(int index) 
+  {
+    setState(() {
+      posts[index].isLike = !posts[index].isLike;
+    });
+  }
+
+  void getInPost(BuildContext context, int index) 
+  {
+    Navigator.of(
+      context
+    ).push(MaterialPageRoute(builder: (ctx) => PostDetail(
+      post: posts[index], 
+      onToggleLike: () {
+        _toggleLike(index);
+      }
+    )));
+  }
+
+  @override
+  Widget build(BuildContext context)
+  {
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.all(10.0),
+        child: GridView.custom(
+          shrinkWrap: true,
+          physics: NeverScrollableScrollPhysics(),
+
+          gridDelegate: SliverWovenGridDelegate.count(
+            pattern: const [
+              WovenGridTile(1.1),
+              WovenGridTile(
+                5/7,
+                crossAxisRatio: 0.9,
+                alignment: AlignmentDirectional.topEnd
+              ),
+            ], 
+            crossAxisCount: 2,
+            mainAxisSpacing: 2.0,
+            crossAxisSpacing: 2.0
+          ),
+          childrenDelegate: SliverChildBuilderDelegate(
+            (BuildContext context, int index)
+            {
+              final Post data = posts[index];
+              return GestureDetector(
+                onTap: () {getInPost(context, index);},
+                child: Container(
+                  decoration: BoxDecoration(
+                    borderRadius: BorderRadius.circular(5),
+                    image: DecorationImage(
+                      image: AssetImage(data.images[0]),
+                      fit: BoxFit.cover
+                    )
+                  ),
+                  child: Column(
+                    children: [
+                      Align(
+                        alignment: Alignment.topLeft,
+                        child: Padding(
+                          padding: const EdgeInsets.all(5.0),
+                          child: Row(
+                            children: [
+                              Stack(
+                                children: [
+                                  Positioned(
+                                    top: 1.0,
+                                    left: 1.0,
+                                    child: Icon(
+                                      Icons.location_pin,
+                                      size: 21,
+                                      color: Colors.black.withOpacity(0.6), // Darker color for outline
+                                    ),
+                                  ),
+                                  Icon(
+                                    Icons.location_pin,
+                                    size: 20,
+                                    color: Colors.white,
+                                ),
+                                ],
+                              ),
+                              
+                              SizedBox(width: 5),
+                              Text(
+                                data.location,
+                                style: TextStyle(
+                                  color: Colors.white,
+                                  fontSize: 16,
+                                  shadows: [
+                                  Shadow(
+                                    offset: Offset(1.0, 1.0),
+                                    blurRadius: 3.0,
+                                    color: Colors.black.withOpacity(0.6),
+                                  ),
+                                  Shadow(
+                                    offset: Offset(-1.0, -1.0),
+                                    blurRadius: 3.0,
+                                    color: Colors.black.withOpacity(0.6),
+                                  ),
+                                ],
+                                ),
+                              )
+                            ],
+                          ),
+                        ),
+                      ),
+                      Spacer(),
+                      Padding(
+                        padding: const EdgeInsets.all(10.0),
+                        child: Row(
+                          children: [
+                            GestureDetector(
+                              onTap: () => _toggleLike(index),
+                              child: Icon(
+                                Icons.favorite,
+                                size: 20,
+                                color: data.isLike ? Colors.red : Colors.white,
+                              ),
+                            ),
+                            Spacer(),
+                            Text(
+                              data.views,
+                              style: TextStyle(
+                                color: Colors.white,
+                                fontSize: 16,
+                                shadows: [
+                                  Shadow(
+                                    offset: Offset(1.0, 1.0),
+                                    blurRadius: 3.0,
+                                    color: Colors.black.withOpacity(0.6),
+                                  ),
+                                  Shadow(
+                                    offset: Offset(-1.0, -1.0),
+                                    blurRadius: 3.0,
+                                    color: Colors.black.withOpacity(0.6),
+                                  ),
+                                ]
+                              ),
+                            ),
+                            SizedBox(width: 5.0),
+                            Icon(
+                              Icons.remove_red_eye_outlined,
+                              size: 20,
+                              color: Colors.white,
+                            ),
+                          ],
+                        ),
+                      )
+                    ],
+                  )
+                )
+              );
+            },
+            childCount: posts.length,
+          )
+        ),
+      ),
+    );
+  }
+}

--- a/lib/Forum/post_detail.dart
+++ b/lib/Forum/post_detail.dart
@@ -1,0 +1,231 @@
+import 'package:flutter/material.dart';
+import 'package:travel_app/Models/post.dart';
+
+class PostDetail extends StatefulWidget {
+  final Post post;
+  final VoidCallback onToggleLike;
+
+  const PostDetail({
+    super.key,
+    required this.post,
+    required this.onToggleLike,
+  });
+
+  @override
+  State<PostDetail> createState() => _PostDetailState();
+}
+
+class _PostDetailState extends State<PostDetail> {
+  late bool _isLiked;
+  late PageController _pageController;
+  int _currentPage = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _isLiked = widget.post.isLike;
+    _pageController = PageController();
+
+    _pageController.addListener(() {
+      setState(() {
+        if (_pageController.page != null) 
+        {
+          _currentPage = _pageController.page!.round();
+        }
+      });
+    });
+  }
+
+    @override
+    void dispose() {
+    _pageController.dispose();
+    super.dispose();
+  }
+
+  void _handleLikeToggle() {
+    setState(() {
+      _isLiked = !_isLiked;
+      widget.onToggleLike();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        backgroundColor: Colors.blueAccent,
+        elevation: 0,
+        leading: IconButton(
+          icon: Icon(
+            Icons.arrow_back, 
+            color: Colors.white
+          ),
+          onPressed: () {
+            Navigator.of(context).pop();
+          },
+        ),
+        title: Row(
+          children: [
+            CircleAvatar(
+              backgroundImage: AssetImage(widget.post.authorImage),
+              radius: 20,
+            ),
+            SizedBox(width: 10),
+            Text(
+              widget.post.authorName,
+              style: TextStyle(
+                color: Colors.white, 
+                fontSize: 18
+              ),
+            ),
+          ],
+        ),
+      ),
+      body: Column(
+        children: [
+          Expanded(
+            child: SingleChildScrollView(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Stack(
+                    children: [
+                      Container(
+                        height: 300,
+                        color: Colors.black.withOpacity(0.9),
+                        child: PageView.builder(
+                          controller: _pageController,
+                          itemCount: widget.post.images.length,
+                          itemBuilder: (context, index) {
+                            return Center(
+                              child: Image.asset(
+                                widget.post.images[index],
+                                fit: BoxFit.contain,
+                              ),
+                            );
+                          },
+                        ),
+                      ),
+                      Positioned(
+                        bottom: 10,
+                        left: 0,
+                        right: 0,
+                        child: Row(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: List.generate(
+                            widget.post.images.length, 
+                            (idx) => buildDot(idx)
+                          ),
+                        )
+                      ),
+                    ],
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.all(16.0),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          widget.post.title,
+                          style: TextStyle(
+                            fontSize: 24,
+                            fontWeight: FontWeight.w600,
+                          ),
+                        ),
+                        SizedBox(height: 10),
+                        Row(
+                          children: [
+                            Icon(
+                              Icons.location_on,
+                              size: 20,
+                              color: Colors.grey[700],
+                            ),
+                            SizedBox(width: 5),
+                            Text(
+                              widget.post.location,
+                              style: TextStyle(
+                                fontSize: 16,
+                                color: Colors.grey[700],
+                              ),
+                            ),
+                          ],
+                        ),
+                        SizedBox(height: 10),
+                        Text(
+                          widget.post.content,
+                          style: TextStyle(
+                            fontSize: 16
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+          Container(
+            color: Theme.of(context).cardColor,
+            padding: const EdgeInsets.symmetric(
+              horizontal: 16.0,
+              vertical: 8.0,
+            ),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceAround,
+              children: [
+                InkWell(
+                  onTap: _handleLikeToggle,
+                  borderRadius: BorderRadius.circular(8.0),
+                  child: Material( 
+                    color: Colors.transparent,
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 4.0,),
+                      child: Row(
+                        children: [
+                          Icon(
+                            Icons.favorite,
+                            color: _isLiked ? Colors.red : Colors.grey,
+                          ),
+                          SizedBox(width: 5),
+                          Text('Like'),
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
+                Row(
+                  children: [
+                    Icon(Icons.share, color: Colors.grey),
+                    SizedBox(width: 5),
+                    Text('Share'),
+                  ],
+                ),
+                Row(
+                  children: [
+                    Icon(Icons.remove_red_eye_outlined, color: Colors.grey),
+                    SizedBox(width: 5),
+                    Text(widget.post.views),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget buildDot(int index) 
+  {
+    bool isCurrent = index == _currentPage;
+    return Container(
+      margin: const EdgeInsets.symmetric(horizontal: 4.0),
+      height: isCurrent ? 6.0 : 5.0,
+      width: isCurrent ? 6.0 : 5.0,
+      decoration: BoxDecoration(
+        color: isCurrent ? Colors.white : Colors.white.withOpacity(0.5),
+        shape: BoxShape.circle
+      ),
+    );
+  }
+}

--- a/lib/Forum/post_detail.dart
+++ b/lib/Forum/post_detail.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:travel_app/Models/post.dart';
 
-class PostDetail extends StatefulWidget {
+class PostDetail extends StatefulWidget 
+{
   final Post post;
   final VoidCallback onToggleLike;
 
@@ -15,34 +16,38 @@ class PostDetail extends StatefulWidget {
   State<PostDetail> createState() => _PostDetailState();
 }
 
-class _PostDetailState extends State<PostDetail> {
+class _PostDetailState extends State<PostDetail> 
+{
   late bool _isLiked;
-  late PageController _pageController;
+  late PageController _imagePageController;
   int _currentPage = 0;
 
   @override
-  void initState() {
+  void initState() 
+  {
     super.initState();
     _isLiked = widget.post.isLike;
-    _pageController = PageController();
+    _imagePageController = PageController();
 
-    _pageController.addListener(() {
+    _imagePageController.addListener(() {
       setState(() {
-        if (_pageController.page != null) 
+        if (_imagePageController.page != null) 
         {
-          _currentPage = _pageController.page!.round();
+          _currentPage = _imagePageController.page!.round();
         }
       });
     });
   }
 
-    @override
-    void dispose() {
-    _pageController.dispose();
-    super.dispose();
+  @override
+  void dispose() 
+  {
+  _imagePageController.dispose();
+  super.dispose();
   }
 
-  void _handleLikeToggle() {
+  void _handleLikeToggle() 
+  {
     setState(() {
       _isLiked = !_isLiked;
       widget.onToggleLike();
@@ -50,7 +55,8 @@ class _PostDetailState extends State<PostDetail> {
   }
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context) 
+  {
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Colors.blueAccent,
@@ -90,17 +96,44 @@ class _PostDetailState extends State<PostDetail> {
                 children: [
                   Stack(
                     children: [
+                      //For blur background
+                      // Container(
+                      //   height: 300,
+                      //   child: ClipRect(
+                      //     child: Stack(
+                      //       children: [
+                      //         Image.asset(
+                      //           widget.post.images[_currentPage],
+                      //           fit: BoxFit.cover,
+                      //           width: double.infinity,
+                      //           height: double.infinity,
+                      //         ),
+                      //         BackdropFilter(
+                      //           filter: ImageFilter.blur(
+                      //             sigmaX: 10.0,
+                      //             sigmaY: 10.0,
+                      //           ), 
+                      //           child: Container(
+                      //             color: Colors.black.withOpacity(0.3),
+                      //           ),
+                      //         ),
+                      //       ],
+                      //     ),
+                      //   ),
+                      // ),
                       Container(
                         height: 300,
-                        color: Colors.black.withOpacity(0.9),
                         child: PageView.builder(
-                          controller: _pageController,
+                          controller: _imagePageController,
                           itemCount: widget.post.images.length,
                           itemBuilder: (context, index) {
                             return Center(
                               child: Image.asset(
                                 widget.post.images[index],
-                                fit: BoxFit.contain,
+                                //fit: BoxFit.contain //This is for blur background
+                                fit: BoxFit.cover,
+                                width: double.infinity,
+                                height: double.infinity,
                               ),
                             );
                           },
@@ -166,9 +199,11 @@ class _PostDetailState extends State<PostDetail> {
           ),
           Container(
             color: Theme.of(context).cardColor,
-            padding: const EdgeInsets.symmetric(
-              horizontal: 16.0,
-              vertical: 8.0,
+            padding: const EdgeInsets.only(
+              left: 12.0,
+              right: 12.0,
+              bottom: 16.0,
+              top: 8.0
             ),
             child: Row(
               mainAxisAlignment: MainAxisAlignment.spaceAround,

--- a/lib/Models/post.dart
+++ b/lib/Models/post.dart
@@ -5,6 +5,8 @@ class Post {
   List<String> images;
   String authorName;
   String authorImage;
+  String location;
+  bool isLike = false;
 
   Post({
     required this.title,
@@ -13,6 +15,7 @@ class Post {
     required this.images,
     required this.authorName,
     required this.authorImage,
+    required this.location
   });
 
   static List<Post> getAllPosts() {
@@ -24,9 +27,10 @@ class Post {
         content:
             "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut scelerisque neque aliquam sollicitudin interdum. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut scelerisque neque aliquam sollicitudin interdum.",
         views: "60k",
-        images: ["assets/images/xmum.jpg"],
+        images: ["assets/images/xmum.jpg", "assets/images/melina.jpg"],
         authorName: "Melina",
         authorImage: "assets/images/melina.jpg",
+        location: "Malaysia",
       ),
     );
 
@@ -39,6 +43,7 @@ class Post {
         images: ["assets/images/xmum.jpg"],
         authorName: "Melina",
         authorImage: "assets/images/melina.jpg",
+        location: "Malaysia",
       ),
     );
 
@@ -51,6 +56,7 @@ class Post {
         images: ["assets/images/xmum.jpg"],
         authorName: "Melina",
         authorImage: "assets/images/melina.jpg",
+        location: "Malaysia",
       ),
     );
 
@@ -63,6 +69,7 @@ class Post {
         images: ["assets/images/xmum.jpg"],
         authorName: "Melina",
         authorImage: "assets/images/melina.jpg",
+        location: "Malaysia",
       ),
     );
 
@@ -75,6 +82,7 @@ class Post {
         images: ["assets/images/xmum.jpg"],
         authorName: "Melina",
         authorImage: "assets/images/melina.jpg",
+        location: "Malaysia",
       ),
     );
 
@@ -87,6 +95,7 @@ class Post {
         images: ["assets/images/xmum.jpg"],
         authorName: "Melina",
         authorImage: "assets/images/melina.jpg",
+        location: "Malaysia",
       ),
     );
 

--- a/lib/Models/post.dart
+++ b/lib/Models/post.dart
@@ -1,4 +1,5 @@
 class Post {
+  int? id;
   String title;
   String content;
   String views;
@@ -99,6 +100,37 @@ class Post {
       ),
     );
 
-    return posts;
+    posts.add(
+      Post(
+        title: "A memorable summer adventure in Malaysia",
+        content:
+            "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut scelerisque neque aliquam sollicitudin interdum. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut scelerisque neque aliquam sollicitudin interdum.",
+        views: "60k",
+        images: ["assets/images/xmum.jpg"],
+        authorName: "Melina",
+        authorImage: "assets/images/melina.jpg",
+        location: "Malaysia",
+      ),
+    );
+
+    posts.add(
+      Post(
+        title: "A memorable summer adventure in Malaysia",
+        content:
+            "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut scelerisque neque aliquam sollicitudin interdum. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut scelerisque neque aliquam sollicitudin interdum.",
+        views: "60k",
+        images: ["assets/images/xmum.jpg"],
+        authorName: "Melina",
+        authorImage: "assets/images/melina.jpg",
+        location: "Malaysia",
+      ),
+    );
+
+    for (int i = 0; i < posts.length; i++) 
+    {
+      posts[i].id = i;
+    }
+
+    return posts; 
   }
 }

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:travel_app/Forum/Forum.dart';
+import 'package:travel_app/Forum/forum.dart';
 import 'package:travel_app/Login/Login.dart';
 import 'package:travel_app/Memo/Memo.dart';
 import 'package:travel_app/home_page.dart';

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -70,6 +70,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.0.0"
+  flutter_staggered_grid_view:
+    dependency: "direct main"
+    description:
+      name: flutter_staggered_grid_view
+      sha256: "19e7abb550c96fbfeb546b23f3ff356ee7c59a019a651f8f102a4ba9b7349395"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
+  flutter_staggered_grid_view: ^0.7.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
The experience page is designed with grids
![image](https://github.com/user-attachments/assets/217a33a6-c52b-4fd5-b12a-bd931308eb38)
and the like is clickable in this page directly without reading the details in the page

when click on the grid will guide to the detail page
![image](https://github.com/user-attachments/assets/047ffa9f-87cf-4513-bb1c-4870123e1d30)
![image](https://github.com/user-attachments/assets/b7df10d2-85c0-48e9-8ee6-beca3b998743)
with scrollable image and details

You can like the post in this page too and it will update when return to the experience page same goes with like in experience page will carry forward

**Notes**
1. The **inkwell** is not function for provide highlight on clicking the **like in the post page** and clicking the **grid in experience page**
2. The share button is not set to function

Kindly leave comments to make any changes or improvement to the pages