### PR TITLE
Resolving Andriod ndk under version required issue through hard coding

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 android {
     namespace = "com.example.travel_app"
     compileSdk = flutter.compileSdkVersion
-    ndkVersion = flutter.ndkVersion
+    ndkVersion = "27.0.12077973"
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11


### PR DESCRIPTION
Resolve through hardcode the ndk version in /android/app/build.gradle.kts
from
![image](https://github.com/user-attachments/assets/57ad86ab-df68-4501-8ced-d2f441d392a3)
into
![image](https://github.com/user-attachments/assets/6c932da1-70b4-4719-b4b8-2368cbd0c150)
which required when launching the app