### PR TITLE
Text style and background update in Experiences

### DIFF
--- a/lib/Forum/Forum.dart
+++ b/lib/Forum/Forum.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
 import 'package:travel_app/Forum/forum_grids.dart';
 
 class Forum extends StatefulWidget 
@@ -19,12 +20,13 @@ class _ForumState extends State<Forum>
           Padding(
             padding: EdgeInsets.symmetric(vertical: 10, horizontal: 10),
             child: Row(
+              mainAxisAlignment: MainAxisAlignment.center,
               children: [
                 Text(
                   'Experiences',
-                  style: TextStyle(
+                  style: GoogleFonts.ubuntu(
                     fontWeight: FontWeight.w600,
-                    fontSize: 20
+                    fontSize: 20,
                   ),
                 ),
               ],

--- a/lib/Forum/forum_grids.dart
+++ b/lib/Forum/forum_grids.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
 import 'package:travel_app/Forum/post_detail.dart';
 import 'package:travel_app/Models/post.dart';
 import 'package:flutter_staggered_grid_view/flutter_staggered_grid_view.dart';
@@ -146,7 +147,7 @@ class _ExperienceGridsState extends State<ExperienceGrids>
                                   Flexible(
                                     child: Text(
                                       data.location,
-                                      style: TextStyle(
+                                      style: GoogleFonts.ubuntu(
                                         color: Colors.white,
                                         fontSize: 16,
                                         shadows: [
@@ -206,7 +207,7 @@ class _ExperienceGridsState extends State<ExperienceGrids>
                                   const Spacer(),
                                   Text(
                                     data.views,
-                                    style: TextStyle(
+                                    style: GoogleFonts.ubuntu(
                                       color: Colors.white,
                                       fontSize: 16,
                                       shadows: [
@@ -253,7 +254,7 @@ class _ExperienceGridsState extends State<ExperienceGrids>
                         padding: const EdgeInsets.fromLTRB(8.0, 8.0, 8.0, 0.0),
                         child: Text(
                           data.title,
-                          style: const TextStyle(
+                          style: GoogleFonts.ubuntu(
                             fontSize: 16,
                             fontWeight: FontWeight.bold,
                             color: Colors.black,
@@ -274,7 +275,7 @@ class _ExperienceGridsState extends State<ExperienceGrids>
                             Flexible(
                               child: Text(
                                 data.authorName,
-                                style: TextStyle(
+                                style: GoogleFonts.ubuntu(
                                   fontSize: 14,
                                   color: Colors.grey[700],
                                 ),

--- a/lib/Forum/post_detail.dart
+++ b/lib/Forum/post_detail.dart
@@ -1,6 +1,7 @@
 import 'dart:ui';
 
 import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
 import 'package:travel_app/Models/post.dart';
 
 class PostDetail extends StatefulWidget 
@@ -60,6 +61,7 @@ class _PostDetailState extends State<PostDetail>
   Widget build(BuildContext context) 
   {
     return Scaffold(
+      backgroundColor: Color(0xfff5f5f5),
       appBar: AppBar(
         backgroundColor: Colors.blueAccent,
         elevation: 0,
@@ -81,7 +83,7 @@ class _PostDetailState extends State<PostDetail>
             SizedBox(width: 10),
             Text(
               widget.post.authorName,
-              style: TextStyle(
+              style: GoogleFonts.ubuntu(
                 color: Colors.white, 
                 fontSize: 18
               ),
@@ -163,7 +165,7 @@ class _PostDetailState extends State<PostDetail>
                       children: [
                         Text(
                           widget.post.title,
-                          style: TextStyle(
+                          style: GoogleFonts.ubuntu(
                             fontSize: 24,
                             fontWeight: FontWeight.w600,
                           ),
@@ -174,14 +176,14 @@ class _PostDetailState extends State<PostDetail>
                             Icon(
                               Icons.location_on,
                               size: 20,
-                              color: Colors.grey[700],
+                              color: Color(0xff41729f),
                             ),
                             SizedBox(width: 5),
                             Text(
                               widget.post.location,
-                              style: TextStyle(
+                              style: GoogleFonts.ubuntu(
                                 fontSize: 16,
-                                color: Colors.grey[700],
+                                color: Color(0xff41729f),
                               ),
                             ),
                           ],
@@ -189,7 +191,7 @@ class _PostDetailState extends State<PostDetail>
                         SizedBox(height: 10),
                         Text(
                           widget.post.content,
-                          style: TextStyle(
+                          style: GoogleFonts.ubuntu(
                             fontSize: 16
                           ),
                         ),
@@ -201,12 +203,12 @@ class _PostDetailState extends State<PostDetail>
             ),
           ),
           Container(
-            color: Theme.of(context).cardColor,
+            color: Color(0xfff5f5f5),
             padding: const EdgeInsets.only(
               left: 12.0,
               right: 12.0,
-              bottom: 16.0,
-              top: 8.0
+              bottom: 20.0,
+              top: 12.0
             ),
             child: Row(
               mainAxisAlignment: MainAxisAlignment.spaceAround,
@@ -225,7 +227,10 @@ class _PostDetailState extends State<PostDetail>
                             color: _isLiked ? Colors.red : Colors.grey,
                           ),
                           SizedBox(width: 5),
-                          Text('Like'),
+                          Text(
+                            'Like',
+                            style: GoogleFonts.ubuntu(),
+                          ),
                         ],
                       ),
                     ),
@@ -235,14 +240,20 @@ class _PostDetailState extends State<PostDetail>
                   children: [
                     Icon(Icons.share, color: Colors.grey),
                     SizedBox(width: 5),
-                    Text('Share'),
+                    Text(
+                      'Share',
+                      style: GoogleFonts.ubuntu()
+                    ),
                   ],
                 ),
                 Row(
                   children: [
                     Icon(Icons.remove_red_eye_outlined, color: Colors.grey),
                     SizedBox(width: 5),
-                    Text(widget.post.views),
+                    Text(
+                      widget.post.views,
+                      style: GoogleFonts.ubuntu()
+                    ),
                   ],
                 ),
               ],

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -6,9 +6,11 @@ import FlutterMacOS
 import Foundation
 
 import file_selector_macos
+import path_provider_foundation
 import shared_preferences_foundation
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
+  PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -57,6 +57,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.3.4+2"
+  crypto:
+    dependency: transitive
+    description:
+      name: crypto
+      sha256: "1e445881f28f22d6140f181e07737b22f1e099a5e1ff94b0af2f9e4a463f4855"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.6"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -160,6 +168,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  google_fonts:
+    dependency: "direct main"
+    description:
+      name: google_fonts
+      sha256: b1ac0fe2832c9cc95e5e88b57d627c5e68c223b9657f4b96e1487aa9098c7b82
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.2.1"
   http:
     dependency: transitive
     description:
@@ -312,6 +328,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  path_provider:
+    dependency: transitive
+    description:
+      name: path_provider
+      sha256: "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.5"
+  path_provider_android:
+    dependency: transitive
+    description:
+      name: path_provider_android
+      sha256: d0d310befe2c8ab9e7f393288ccbb11b60c019c6b5afc21973eeee4dda2b35e9
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.17"
+  path_provider_foundation:
+    dependency: transitive
+    description:
+      name: path_provider_foundation
+      sha256: "4843174df4d288f5e29185bd6e72a6fbdf5a4a4602717eed565497429f179942"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
   path_provider_linux:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,6 +38,7 @@ dependencies:
   image_picker: ^1.0.4
   flutter_staggered_grid_view: ^0.7.0
   carousel_slider: ^5.0.0
+  google_fonts: ^6.2.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
# Preview
![image](https://github.com/user-attachments/assets/b24f912d-f7e1-4264-a2b2-4e65dbd85cb5)
![image](https://github.com/user-attachments/assets/433f9655-2815-4680-847e-3d2b763f66dd)

# Update Detail
The post detail page app bar color remain unchanged here since change made in discussion just down.
This pull request does include the `google_fonts` library.

### How to change the text font quickly
1. Find all TextStyle written for the text
2. Replace them with `GoogleFonts.ubuntu`

#### Make sure that you have include the `google_fonts` library, if not `$ flutter pub add google_fonts`

# Inconsistency design with memo page
The memo page passing the title through an appbar which will always show in the top of the page, but I am just past the experience title in a list view, which will be scrolled up.
But this is a small issue, do ignore if it's fine so.